### PR TITLE
프로젝트 홈 - 사이드바 경로 수정

### DIFF
--- a/src/main/resources/templates/dashboard/index.html
+++ b/src/main/resources/templates/dashboard/index.html
@@ -7,6 +7,8 @@
 	<div th:replace="partials/title-meta :: title-meta('Team Plus')"></div>
 </th:block>
 
+<!-- Todo 사용하지 않는 파일 / 폐기 예정 - 10.23 (재민) -->
+
 <head>
 	<!-- jsvectormap css -->
 	<link href="/assets/libs/jsvectormap/css/jsvectormap.min.css" rel="stylesheet" type="text/css" />

--- a/src/main/resources/templates/dashboard/projects.html
+++ b/src/main/resources/templates/dashboard/projects.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
-	  layout:decorate="~{project-index-layout}">
+	  layout:decorate="~{layout}">
 
 <th:block layout:fragment="pagetitle">
 	<!--page title-->


### PR DESCRIPTION
프로젝트 홈 화면이 [dashboard] - [index.html] ▶ [projects.html] 로 변경되었으므로 해당 파일의 사이드바 경로 수정

※ [dashboard] - [index.html] 파일은 더이상 사용하지 않아 삭제해야 하지만, 현재 연결되어있는 파일이 많아 삭제하기 어려우므로 추후 삭제해야 함.